### PR TITLE
v1.5.2 - splitting empty `name` & bump `flutter_lints`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.2
+
+* Increase safety on splitting empty `name` strings to abbreviation by [@MrLightful](https://github.com/MrLightful).
+* Bump `flutter_lints` to major v5.0.0 & fix analysis issues by [@MrLightful](https://github.com/MrLightful).
+
 ## 1.5.1
 
 * Fix `name` splitting with emojis by [@MrLightful](https://github.com/MrLightful).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.5.1
 
-* Fix `displayName` splitting with emojis by [@MrLightful](https://github.com/MrLightful).
+* Fix `name` splitting with emojis by [@MrLightful](https://github.com/MrLightful).
 
 ## 1.5.0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,8 +6,10 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -64,7 +66,7 @@ class _MyAppState extends State<MyApp> {
                     alignment: Alignment.topLeft,
                     size: Size.square(32),
                     child: GestureDetector(
-                      onTap: () => print('Close Tap'),
+                      onTap: () => debugPrint('Close Tap'),
                       child: Container(
                         width: 32,
                         height: 32,
@@ -81,7 +83,7 @@ class _MyAppState extends State<MyApp> {
                         child: Icon(Icons.close),
                       ),
                     ),
-                  )
+                  ),
                 ],
               ),
               AdvancedAvatar(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,23 +28,23 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.1"
+    version: "1.5.2"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -59,4 +59,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0-0 <4.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.2"
+    version: "1.5.1"
   material_color_utilities:
     dependency: transitive
     description:

--- a/lib/src/advanced_avatar.dart
+++ b/lib/src/advanced_avatar.dart
@@ -12,7 +12,7 @@ const _defaultAbbreviationFontSize = 15.0;
 /// Advanced Avatar widget.
 class AdvancedAvatar extends StatelessWidget {
   const AdvancedAvatar({
-    Key? key,
+    super.key,
     this.name,
     this.size = _defaultAvatarSize,
     this.image,
@@ -31,7 +31,7 @@ class AdvancedAvatar extends StatelessWidget {
     this.animated = false,
     this.duration = const Duration(milliseconds: 300),
     this.autoTextSize = false,
-  }) : super(key: key);
+  });
 
   /// Used for creating initials. (Regex split by r'\s+\/')
   final String? name;

--- a/lib/src/advanced_avatar_inherited.dart
+++ b/lib/src/advanced_avatar_inherited.dart
@@ -2,10 +2,10 @@ part of 'advanced_avatar.dart';
 
 class AdvancedAvatarInherited extends InheritedWidget {
   const AdvancedAvatarInherited({
-    Key? key,
-    required Widget child,
+    super.key,
+    required super.child,
     required this.radius,
-  }) : super(key: key, child: child);
+  });
 
   final double radius;
 

--- a/lib/src/align_circular.dart
+++ b/lib/src/align_circular.dart
@@ -4,12 +4,12 @@ import 'package:flutter_advanced_avatar/flutter_advanced_avatar.dart';
 /// Common positioned widget wrapper.
 class AlignCircular extends StatelessWidget {
   const AlignCircular({
-    Key? key,
+    super.key,
     required this.child,
     this.alignment = Alignment.center,
     this.radius = 0.0,
     this.size = Size.zero,
-  }) : super(key: key);
+  });
 
   /// The [child] alignment.
   final Alignment alignment;

--- a/lib/src/string_extension.dart
+++ b/lib/src/string_extension.dart
@@ -13,11 +13,12 @@ enum AvatarMinLength {
 extension StringExtension on String? {
   /// Returns a string abbreviation.
   String toAbbreviation([AvatarMinLength minLength = AvatarMinLength.one]) {
-    if (this == null) {
+    final trimmed = this?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
       return '';
     }
 
-    final nameParts = this!.trim.call().toUpperCase().split(RegExp(r'[\s/]+'));
+    final nameParts = trimmed.toUpperCase().split(RegExp(r'[\s/]+'));
 
     if (nameParts.length > 1) {
       return nameParts.first.characters.first + nameParts[1].characters.first;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,18 +26,18 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "5.0.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "5.0.0"
   material_color_utilities:
     dependency: transitive
     description:
@@ -68,4 +68,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.3.0-0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,18 +42,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -68,4 +68,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0-0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   characters: ^1.3.0
 
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_advanced_avatar
 description: An advanced avatar provides a rich API for widget customization that opens a new look and feel in your app.
-version: 1.5.1
+version: 1.5.2
 homepage: https://github.com/alex-melnyk/flutter_advanced_avatar
 repository: https://github.com/alex-melnyk/flutter_advanced_avatar
 issue_tracker: https://github.com/alex-melnyk/flutter_advanced_avatar/issues


### PR DESCRIPTION
## Issues
- When attempting to split empty string, or one with only spaces, `toAbbreviation` crashes (bug introduced by #10).
- `flutter_lints` is too outdated; currently `v2`, while the latest is `v5`.

## Changes
* Increase safety on splitting empty `name` strings to abbreviation.
* Bump `flutter_lints` to major v5.0.0 & fix analysis issues.
* Minor fix for `CHANGELOG` for v1.5.1 record.
* Bump package version to v1.5.2.